### PR TITLE
BO: Categories Breadcrumbs retrieving causes OutOfMemory for large Category Tree

### DIFF
--- a/src/Adapter/Category/CategoryDataProvider.php
+++ b/src/Adapter/Category/CategoryDataProvider.php
@@ -150,20 +150,23 @@ class CategoryDataProvider
      *
      * @return array Categories
      */
-    public function getCategoriesWithBreadCrumb()
+    public function getCategoriesWithBreadCrumb($delimiter = ' > ')
     {
-        $allCategories = $this->getAllCategoriesName();
+        $context = \ContextCore::getContext();
+        $db = \DbCore::getInstance();
 
-        $results = [];
-        foreach ($allCategories as $category) {
-            $results[] = [
-                'id' => $category['id_category'],
-                'name' => $category['name'],
-                'breadcrumb' => $this->getBreadCrumb($category['id_category'])
-            ];
-        }
+        return $db->executeS('SELECT cl.`id_category` as "id", cl.`name`, (SELECT GROUP_CONCAT(cl.name SEPARATOR "'.$delimiter.'")
+                                FROM `'._DB_PREFIX_.'category` c
+                                INNER JOIN `'._DB_PREFIX_.'category_shop` category_shop ON (category_shop.id_category = c.id_category AND category_shop.id_shop = '.$context->shop->id.')
+                                INNER JOIN `'._DB_PREFIX_.'category_lang` cl ON (c.`id_category` = cl.`id_category` AND cl.id_shop = ' . $context->shop->id . ' AND cl.id_lang = ' . $context->language->id . ')
+                                RIGHT JOIN `'._DB_PREFIX_.'category` c2 ON  c.`nleft` <= c2.`nleft` AND c.`nright` >= c2.`nright`
+                                WHERE 1 AND c.id_category IS NOT NULL AND c.`level_depth` > 0 AND c2.`id_category` = X.`id_category`) AS "breadcrumb"
 
-        return $results;
+                                FROM `'._DB_PREFIX_.'category` X
+                                INNER JOIN `'._DB_PREFIX_.'category_shop` XS ON (XS.`id_category` = X.`id_category` AND XS.id_shop = '.$context->shop->id.')
+                                INNER JOIN `'._DB_PREFIX_.'category_lang` cl ON (cl.`id_category` = X.`id_category` AND cl.id_shop = ' . $context->shop->id . ' AND cl.id_lang = ' . $context->language->id . ')
+                                GROUP BY X.`id_category`
+                                ORDER BY X.`nleft` ');
     }
 
     /**


### PR DESCRIPTION
We tested the original solution in a tree with more than 350 categories and result is an Out Of Memory (PHP 7.1, memory_limit = 2G)

The proposed solution redefine the getCategoriesWithBreadCrumb() method in order to retrieve all the breadcrumbs for every category directly from a query, thanks to the binary search attributes.

Every suggestion is really appreciated ;)